### PR TITLE
Add GitHub Actions CI/CD support.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: SshConfig tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        swift: ["5.1", "5.2", "5.3", "5.4"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: fwal/setup-swift@v1
+        with:
+          swift-version: ${{ matrix.swift }}
+      - uses: actions/checkout@v2
+      - name: Build
+        run: swift build
+      - name: Run tests
+        run: swift test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test_macOS:
-    name: Swift tests on the latest MacOS
+    name: Tests on the MacOS
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
       run: swift test
 
   test_linux:
-    name: Swift tests on the latest Ubuntu (${{ matrix.image }})
+    name: Tests with ${{ matrix.image }} on the Ubuntu
     strategy:
       matrix:
         image: ["swift:5.1", "swift:5.2", "swift:5.3", "swift:5.4"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,19 +9,26 @@ on:
       - '*'
 
 jobs:
-  build:
-    name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
+  test_macOS:
+    name: Swift tests on the latest MacOS
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: swift build
+    - name: Run tests
+      run: swift test
+
+  test_linux:
+    name: Swift tests on the latest Ubuntu (${{ matrix.image }})
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        swift: ["5.1", "5.2", "5.3", "5.4"]
-    runs-on: ${{ matrix.os }}
+        image: ["swift:5.1", "swift:5.2", "swift:5.3", "swift:5.4"]
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
     steps:
-      - uses: fwal/setup-swift@v1
-        with:
-          swift-version: ${{ matrix.swift }}
-      - uses: actions/checkout@v2
-      - name: Build
-        run: swift build
-      - name: Run tests
-        run: swift test
+    - uses: actions/checkout@v2
+    - name: Build
+      run: swift build
+    - name: Run tests
+      run: swift test


### PR DESCRIPTION
Motivation:

It's a good practice to have a CI/CD for a project.

Modifications:

- Add a GitHub Action's YAML file.

Result:

Should run build and test for each push and PR action.