### PR TITLE
Adding PR and issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+### Expected behavior
+_[what you expected to happen]_
+
+### Actual behavior
+_[what actually happened]_
+
+### Steps to reproduce
+
+1. ...
+2. ...
+
+### If possible, minimal yet complete reproducer code (or URL to code)
+
+_[anything to help us reproducing the issue]_
+
+### SwiftNIO version/commit hash
+
+_[the SwiftNIO tag/commit hash]_
+
+### Swift & OS version (output of `swift --version && uname -a`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+_[One line description of your change]_
+
+### Motivation:
+
+_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_
+
+### Modifications:
+
+_[Describe the modifications you've done.]_
+
+### Result:
+
+_[After your change, what will change.]_


### PR DESCRIPTION
Adding PR and issue templates.

Motivation:

I would like to see the standard-looking issues and PRs 
messages in the repo.

Modifications:

- Add the issues template;
- Add the PRs template.

Result:

The issues/PRs now have the templates to create.